### PR TITLE
Fix start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "gatsby build",
     "dev": "gatsby develop",
-    "start": "npm run develop",
+    "start": "npm run dev",
     "serve": "gatsby serve",
     "deploy": "gatsby build && gh-pages -d public",
     "test": "echo \"Write tests! -> https://gatsby.app/unit-testing\""


### PR DESCRIPTION
Fixes the typical entry point for most projects, `yarn start`. If the `develop` command is supposed to exist separately from `dev`, I'd be more than happy to add it

There is no `develop` command, only `dev`